### PR TITLE
Use strict equality/inequality operator & use const/let over var

### DIFF
--- a/src/polyfills.js
+++ b/src/polyfills.js
@@ -1,19 +1,19 @@
-if (typeof Object.assign != 'function') {
+if (typeof Object.assign !== 'function') {
   // Must be writable: true, enumerable: false, configurable: true
   Object.defineProperty(Object, "assign", {
     value: function assign(target, varArgs) { // .length of function is 2
       'use strict';
-      if (target == null) { // TypeError if undefined or null
+      if (target === null) { // TypeError if undefined or null
         throw new TypeError('Cannot convert undefined or null to object');
       }
 
-      var to = Object(target);
+      const to = Object(target);
 
-      for (var index = 1; index < arguments.length; index++) {
-        var nextSource = arguments[index];
+      for (let index = 1; index < arguments.length; index++) {
+        const nextSource = arguments[index];
 
-        if (nextSource != null) { // Skip over if undefined or null
-          for (var nextKey in nextSource) {
+        if (nextSource !== null) { // Skip over if undefined or null
+          for (let nextKey in nextSource) {
             // Avoid bugs when hasOwnProperty is shadowed
             if (Object.prototype.hasOwnProperty.call(nextSource, nextKey)) {
               to[nextKey] = nextSource[nextKey];


### PR DESCRIPTION
The current implementation of the polyfill uses equality/inequality operators that only compare the underlying values of two operands and don't check their types. Using strict equality/inequality operators enhances the code as even the types of operands are checked.

The current implementation also uses `var` for declaring variables in contrast to using `let` and `const`. Since the polyfill is transpiled, it is safe to use `let` and `const` over `var`.

